### PR TITLE
Fix comma typo in state object

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ With that, we can set the application state as:
 
 ```
 {
-  authors: //array of authors
-  books: // array of books,
+  authors: //array of authors,
+  books: // array of books`
 }
 ```
 


### PR DESCRIPTION
Not a big deal, just for clarity's sake